### PR TITLE
Add missing default for nginx_etcdir @ Debian.yml

### DIFF
--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -2,5 +2,6 @@
 www_user: 'www-data'
 www_group: 'www-data'
 www_default_root: '/var/www/html'
+nginx_etcdir: '/etc/nginx'
 nginx_mods_path: '/usr/lib/nginx/modules'
 nginx_modsprefix: 'modules/'


### PR DESCRIPTION
Resolves  `FAILED! => {
    "msg": "The task includes an option with an undefined variable. The error was: 'nginx_etcdir' is undefined

    The error appears to have been in '/var/www/ansible/roles/criecm.nginx/tasks/main.yml': line 8, column 5, but may
    be elsewhere in the file depending on the exact syntax problem.
    The offending line appears to be:
    - block:
        - name: default config
        ^ here\n"
`