### PR TITLE
add default syslog off.

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -35,3 +35,5 @@ syslog_facility: local5
 do_local_log: True
 
 mysite: ''
+
+syslog_server: False


### PR DESCRIPTION
Fixes 
` FAILED! => {
    "changed": false,
    "msg": "AnsibleUndefinedVariable: 'syslog_server' is undefined"
}`