### PR TITLE
Fix typo for loop_var

### DIFF
--- a/tasks/mods-Debian.yml
+++ b/tasks/mods-Debian.yml
@@ -12,7 +12,7 @@
     state: present
   with_items: '{{ nginx_modules }}'
   loop_control:
-    loop_vars: module
+    loop_var: module
   when: module not in lsmods.stdout_lines
   notify: restart nginx
   tags: nginx, config


### PR DESCRIPTION
`loop_vars` => `loop_var`